### PR TITLE
add_pankuzu

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,3 +85,4 @@ gem 'active_hash'
 gem 'dropzonejs-rails'
 gem 'mechanize'
 gem 'ancestry'
+gem "gretel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,8 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -359,6 +361,7 @@ DEPENDENCIES
   erb2haml
   fog-aws
   font-awesome-rails
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,3 +27,12 @@
   @import 'item__exhibit';
   @import 'person_confirm';
 
+.breadcrumbs{
+  height: 49px;
+  line-height: 49px;
+  padding-left: 330px;
+  border-bottom: solid #eee 1px;
+  border-top: solid #eee 1px;
+  font-size: 14px;
+  background-color: white;
+}

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,5 +1,7 @@
 .back 
   = render "header"
+  - breadcrumb :user_registe
+  = breadcrumbs separator: " &rsaquo; "
   .main
     = render "users/sideber"
     .person

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,5 +1,7 @@
 .edit
   = render 'items/header'
+  - breadcrumb :profile
+  = breadcrumbs separator: " &rsaquo; "
   .main
     = render 'sideber'
     .edit__profile

--- a/app/views/users/log_out.html.haml
+++ b/app/views/users/log_out.html.haml
@@ -1,4 +1,6 @@
 = render 'items/header'
+- breadcrumb :log_out
+= breadcrumbs separator: " &rsaquo; "
 
 -# サーバー実装次第form_for(deleteメソッド)
 .wrapper

--- a/app/views/users/register.html.haml
+++ b/app/views/users/register.html.haml
@@ -1,5 +1,7 @@
 .wrapper
   = render 'items/header'
+  - breadcrumb :card
+  = breadcrumbs separator: " &rsaquo; "
   .main
     = render 'users/sideber'
     .right__box

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,5 +1,6 @@
 = render 'items/header'
-
+- breadcrumb :mypage
+= breadcrumbs separator: " &rsaquo; "
 .wrapper
   .main
     = render 'sideber'

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,53 @@
+crumb :root do
+  link "メルカリ", root_path
+end
+
+crumb :mypage do
+  link "マイページ", "/users/:id" 
+end
+
+crumb :card do
+  link "支払い方法", "/users/register"
+  parent :mypage
+end
+
+crumb :profile do
+  link "プロフィール", "/users/:id/edit"
+  parent :mypage
+end
+
+crumb :user_registe do
+  link "本人情報の登録", "/items/:id"
+  parent :mypage
+end
+
+crumb :log_out do
+  link "ログアウト", "/users/log_out"
+  parent :mypage
+end  
+
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).


### PR DESCRIPTION
#what
パンくず機能の実装

#why
パンくず機能を実装する事でユーザーは画面遷移がしやすくなり、ユーザービリティの向上を図ることができるため
